### PR TITLE
Added note about manifest (in)completeness

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -364,7 +364,11 @@ specification, and is not otherwise prescribed.
 A payload manifest is a tag file that lists payload files and checksums for those
 payload files generated using a particular bag checksum algorithm.
 Every bag &must; contain one payload manifest file, and &may; contain
-more than one. A payload manifest file &must;
+more than one.
+</t>
+
+<t>
+A payload manifest file &must;
 have a name of the form manifest-<spanx style="emph">algorithm</spanx>.txt, where
 <spanx style="emph">algorithm</spanx> is a string specifying
 the bag checksum algorithm used in that manifest, such as:
@@ -379,6 +383,13 @@ manifest-sha1.txt
 
 <t>A bag &must-not; contain more than one payload manifest for a particular
 bag checksum algorithm.</t>
+
+<t>
+Each payload manifest file &should; list the checksums for all payload
+files in the bag, including any missing files referenced from
+fetch.txt (see <xref target="sec-fetch-file" />).
+</t>
+
 <t>
 Each line of a payload manifest file &must; be of the form:
 </t>


### PR DESCRIPTION
This fixes #6 by adding a Note to section 3:

> Note that a bag with multiple manifests may be complete even if each of its manifest do not have a  complete list of payload files, as long as every payload file is listed in some manifest file.

As this might give a hint that you should make such incomplete manifests, I countered this with a SHOULD in section 2.1.3:.

>    Each payload manifest file SHOULD list the checksums for all payload files in the bag, including any missing files referenced from fetch.txt (see Section 2.2.3).

This also includes a partial fix for #8.
